### PR TITLE
use a new ruby base image

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6']
+        ruby-version: ['3.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,4 +33,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.3.3


### PR DESCRIPTION
this pulls `ffmpeg`, `ffprobe` and its relevant libraries into a prebuilt (and brand new) Ruby image so that the build process is much, much faster.